### PR TITLE
refactor: keep template-based code same with original

### DIFF
--- a/include/generator_cpp.h
+++ b/include/generator_cpp.h
@@ -60,7 +60,6 @@ private:
     void GenerateImportsProtocol(const std::shared_ptr<Package>& p, bool final);
     void GenerateImportsJson();
     void GenerateImportsJson(const std::shared_ptr<Package>& p);
-    void GenerateBaseModel_Header();
     void GenerateBufferWrapper_Header();
     void GenerateBufferWrapper_Source();
     void GenerateDecimalWrapper_Header();
@@ -125,6 +124,7 @@ private:
     void GenerateFBEModels_Header(const CppCommon::Path& path);
     void GenerateFBEModels_Inline(const CppCommon::Path& path);
     void GenerateFBEModels_Source(const CppCommon::Path& path);
+    void GenerateBaseModel_Header(const CppCommon::Path& path);
     void GenerateFBECustomModels_Header(const CppCommon::Path& path);
     void GenerateFBECustomModels_Inline(const CppCommon::Path& path);
     void GenerateFBEFinalModels_Header(const CppCommon::Path& path);

--- a/include/generator_cpp.h
+++ b/include/generator_cpp.h
@@ -121,10 +121,10 @@ private:
     void GenerateFBEJson();
     void GenerateFBE_Header(const CppCommon::Path& path);
     void GenerateFBE_Source(const CppCommon::Path& path);
+    void GenerateFBEPtr_Header(const CppCommon::Path& path);
     void GenerateFBEModels_Header(const CppCommon::Path& path);
     void GenerateFBEModels_Inline(const CppCommon::Path& path);
     void GenerateFBEModels_Source(const CppCommon::Path& path);
-    void GenerateBaseModel_Header(const CppCommon::Path& path);
     void GenerateFBECustomModels_Header(const CppCommon::Path& path);
     void GenerateFBECustomModels_Inline(const CppCommon::Path& path);
     void GenerateFBEFinalModels_Header(const CppCommon::Path& path);

--- a/source/generator_cpp.cpp
+++ b/source/generator_cpp.cpp
@@ -22,7 +22,7 @@ void GeneratorCpp::Generate(const std::shared_ptr<Package>& package)
     GenerateFBEModels_Source(_output);
 
     if (Ptr()) {
-        GenerateBaseModel_Header(_output);
+        GenerateFBEPtr_Header(_output);
         GenerateFBECustomModels_Header(_output);
         GenerateFBECustomModels_Inline(_output);
 

--- a/source/generator_cpp.cpp
+++ b/source/generator_cpp.cpp
@@ -22,6 +22,7 @@ void GeneratorCpp::Generate(const std::shared_ptr<Package>& package)
     GenerateFBEModels_Source(_output);
 
     if (Ptr()) {
+        GenerateBaseModel_Header(_output);
         GenerateFBECustomModels_Header(_output);
         GenerateFBECustomModels_Inline(_output);
 
@@ -6289,9 +6290,6 @@ void GeneratorCpp::GenerateFBE_Header(const CppCommon::Path& path)
     WriteLineIndent("namespace FBE {");
 
     // Generate common body
-    if (Ptr()){
-        GenerateBaseModel_Header();
-    }
     GenerateBufferWrapper_Header();
     GenerateDecimalWrapper_Header();
     GenerateFlagsWrapper_Header();

--- a/source/generator_cpp.inl
+++ b/source/generator_cpp.inl
@@ -8,7 +8,7 @@
 
 namespace FBE {
 
-void GeneratorCpp::GenerateBaseModel_Header(const CppCommon::Path& path)
+void GeneratorCpp::GenerateFBEPtr_Header(const CppCommon::Path& path)
 {
     // Create package path
     CppCommon::Directory::CreateTree(path);

--- a/source/generator_cpp.inl
+++ b/source/generator_cpp.inl
@@ -8,10 +8,25 @@
 
 namespace FBE {
 
-void GeneratorCpp::GenerateBaseModel_Header()
+void GeneratorCpp::GenerateBaseModel_Header(const CppCommon::Path& path)
 {
+    // Create package path
+    CppCommon::Directory::CreateTree(path);
+
+    // Generate the common file
+    CppCommon::Path common = path / "fbe_ptr.h";
+    WriteBegin();
+
+    // Generate common header
+    GenerateHeader("FBE");
+
+    // Generate namespace begin
+    WriteLine();
+    WriteLineIndent("namespace FBE {");
+
     std::string code = R"CODE(
-struct Base{
+struct Base
+{
     virtual ~Base() = default;
 };
 )CODE";
@@ -20,6 +35,17 @@ struct Base{
     code = std::regex_replace(code, std::regex("\n"), EndLine());
 
     Write(code);
+
+    // Generate namespace end
+    WriteLine();
+    WriteLineIndent("} // namespace FBE");
+
+    // Generate common footer
+    GenerateFooter();
+
+    // Store the common file
+    WriteEnd();
+    Store(common);
 }
 
 void GeneratorCpp::GenerateFBEBaseFieldModel_Header()
@@ -1130,6 +1156,7 @@ void GeneratorCpp::GenerateFBECustomModels_Header(const CppCommon::Path& path)
 
     // Generate imports
     GenerateImports("fbe_models.h");
+    GenerateImports("fbe_ptr.h");
 
     // Generate namespace begin
     WriteLine();
@@ -1205,6 +1232,7 @@ void GeneratorCpp::GeneratePtrPackage_Header(const std::shared_ptr<Package>& p)
 
     // Generate imports
     GenerateImports(p);
+    GenerateImports("fbe_ptr.h");
 
     // Generate namespace begin
     WriteLine();


### PR DESCRIPTION
将ptr相关的代码从fbe的公用代码中剥离。这样同一个项目中就可以很容易地共存两种fbe了