### PR TITLE
Add ptr optional

### DIFF
--- a/include/generator_cpp.h
+++ b/include/generator_cpp.h
@@ -84,8 +84,8 @@ private:
     void GenerateFBEFieldModelString_Source();
     void GenerateFBEFieldModelOptional_Header();
     void GenerateFBEFieldModelOptional_Inline();
-    void GenerateFBEFieldModelCustomOptional_Header();
-    void GenerateFBEFieldModelCustomOptional_Inline();
+    void GenerateFBEFieldModelStructOptional_Header();
+    void GenerateFBEFieldModelStructOptional_Inline();
     void GenerateFBEFieldModelArray_Header();
     void GenerateFBEFieldModelArray_Inline();
     void GenerateFBEFieldModelCustomArray_Header();

--- a/include/generator_cpp.h
+++ b/include/generator_cpp.h
@@ -84,6 +84,8 @@ private:
     void GenerateFBEFieldModelString_Source();
     void GenerateFBEFieldModelOptional_Header();
     void GenerateFBEFieldModelOptional_Inline();
+    void GenerateFBEFieldModelCustomOptional_Header();
+    void GenerateFBEFieldModelCustomOptional_Inline();
     void GenerateFBEFieldModelArray_Header();
     void GenerateFBEFieldModelArray_Inline();
     void GenerateFBEFieldModelCustomArray_Header();

--- a/ptr_proto/sa.fbe
+++ b/ptr_proto/sa.fbe
@@ -24,3 +24,10 @@ struct Simple {
   Extra[1] sa;
   Sex sex;
 }
+
+struct Complex {
+  string name;
+  Sex? sex;
+  MyFLags? flag;
+  Extra? extra;
+}

--- a/source/generator_cpp.inl
+++ b/source/generator_cpp.inl
@@ -1930,8 +1930,7 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
                 for (const auto&field : collection_of_optional_fields) {
                     WriteLineIndent("if (arg_" + *field->name + ".has_value()) {");
                     Indent(1);
-                    WriteLineIndent("auto&& _v = arg_" + *field->name + ".value();");
-                    WriteLineIndent(*field->name + ".emplace(std::move(_v));");
+                    WriteLineIndent(*field->name + ".emplace(std::move(arg_" + *field->name + ".value()));");
                     WriteLineIndent("arg_" + *field->name + ".reset();");
                     Indent(-1);
                     WriteLineIndent("}");
@@ -1988,8 +1987,7 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
             if (IsPrimitiveType(*field->type, false)) {
                 WriteLineIndent(*field->name + ".emplace(other." + *field->name + ".value());");
             } else {
-                WriteLineIndent("auto&& _v = other." + *field->name + ".value();");
-                WriteLineIndent(*field->name + ".emplace(std::move(_v));");
+                WriteLineIndent(*field->name + ".emplace(std::move(other." + *field->name + ".value()));");
             }
             WriteLineIndent("other." + *field->name + ".reset();");
             Indent(-1);
@@ -2135,8 +2133,7 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
                 if (IsPrimitiveType(*field->type, false)) {
                     WriteLineIndent(*field->name + ".emplace(other." + *field->name + ".value());");
                 } else {
-                    WriteLineIndent("auto&& _v = other." + *field->name + ".value();");
-                    WriteLineIndent(*field->name + ".emplace(std::move(_v));");
+                    WriteLineIndent(*field->name + ".emplace(std::move(other." + *field->name + ".value()));");
                 }
                 WriteLineIndent("other." + *field->name + ".reset();");
                 Indent(-1);

--- a/source/generator_cpp.inl
+++ b/source/generator_cpp.inl
@@ -102,14 +102,14 @@ public:
     Write(code);
 }
 
-void GeneratorCpp::GenerateFBEFieldModelCustomOptional_Header()
+void GeneratorCpp::GenerateFBEFieldModelStructOptional_Header()
 {
     std::string code = R"CODE(
 template <typename T, typename TStruct>
-class FieldModelCustomOptional
+class FieldModelStructOptional
 {
 public:
-    FieldModelCustomOptional(FBEBuffer& buffer, size_t offset) noexcept: _buffer(buffer), _offset(offset), value(buffer, 0) {}
+    FieldModelStructOptional(FBEBuffer& buffer, size_t offset) noexcept: _buffer(buffer), _offset(offset), value(buffer, 0) {}
 
     // Get the field offset
     size_t fbe_offset() const noexcept { return _offset; }
@@ -164,11 +164,11 @@ public:
     Write(code);
 }
 
-void GeneratorCpp::GenerateFBEFieldModelCustomOptional_Inline()
+void GeneratorCpp::GenerateFBEFieldModelStructOptional_Inline()
 {
     std::string code = R"CODE(
 template <typename T, typename TStruct>
-inline size_t FieldModelCustomOptional<T, TStruct>::fbe_extra() const noexcept
+inline size_t FieldModelStructOptional<T, TStruct>::fbe_extra() const noexcept
 {
     if (!has_value())
         return 0;
@@ -184,7 +184,7 @@ inline size_t FieldModelCustomOptional<T, TStruct>::fbe_extra() const noexcept
 }
 
 template <typename T, typename TStruct>
-inline bool FieldModelCustomOptional<T, TStruct>::has_value() const noexcept
+inline bool FieldModelStructOptional<T, TStruct>::has_value() const noexcept
 {
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
         return false;
@@ -194,7 +194,7 @@ inline bool FieldModelCustomOptional<T, TStruct>::has_value() const noexcept
 }
 
 template <typename T, typename TStruct>
-inline bool FieldModelCustomOptional<T, TStruct>::verify() const noexcept
+inline bool FieldModelStructOptional<T, TStruct>::verify() const noexcept
 {
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
         return true;
@@ -214,7 +214,7 @@ inline bool FieldModelCustomOptional<T, TStruct>::verify() const noexcept
 }
 
 template <typename T, typename TStruct>
-inline size_t FieldModelCustomOptional<T, TStruct>::get_begin() const noexcept
+inline size_t FieldModelStructOptional<T, TStruct>::get_begin() const noexcept
 {
     if (!has_value())
         return 0;
@@ -229,13 +229,13 @@ inline size_t FieldModelCustomOptional<T, TStruct>::get_begin() const noexcept
 }
 
 template <typename T, typename TStruct>
-inline void FieldModelCustomOptional<T, TStruct>::get_end(size_t fbe_begin) const noexcept
+inline void FieldModelStructOptional<T, TStruct>::get_end(size_t fbe_begin) const noexcept
 {
     _buffer.unshift(fbe_begin);
 }
 
 template <typename T, typename TStruct>
-inline void FieldModelCustomOptional<T, TStruct>::get(std::optional<TStruct>& opt) noexcept
+inline void FieldModelStructOptional<T, TStruct>::get(std::optional<TStruct>& opt) noexcept
 {
 
     size_t fbe_begin = get_begin();
@@ -250,7 +250,7 @@ inline void FieldModelCustomOptional<T, TStruct>::get(std::optional<TStruct>& op
 }
 
 template <typename T, typename TStruct>
-inline size_t FieldModelCustomOptional<T, TStruct>::set_begin(bool has_value)
+inline size_t FieldModelStructOptional<T, TStruct>::set_begin(bool has_value)
 {
     assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
     if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
@@ -274,13 +274,13 @@ inline size_t FieldModelCustomOptional<T, TStruct>::set_begin(bool has_value)
 }
 
 template <typename T, typename TStruct>
-inline void FieldModelCustomOptional<T, TStruct>::set_end(size_t fbe_begin)
+inline void FieldModelStructOptional<T, TStruct>::set_end(size_t fbe_begin)
 {
     _buffer.unshift(fbe_begin);
 }
 
 template <typename T, typename TStruct>
-inline void FieldModelCustomOptional<T, TStruct>::set(const std::optional<TStruct>& opt)
+inline void FieldModelStructOptional<T, TStruct>::set(const std::optional<TStruct>& opt)
 {
     size_t fbe_begin = set_begin(opt.has_value());
     if (fbe_begin == 0)
@@ -1365,7 +1365,7 @@ void GeneratorCpp::GenerateFBECustomModels_Header(const CppCommon::Path& path)
     GenerateFBEFieldModelCustomArray_Header();
     GenerateFBEFieldModelCustomVector_Header();
     GenerateFBEFieldModelCustomMap_Header();
-    GenerateFBEFieldModelCustomOptional_Header();
+    GenerateFBEFieldModelStructOptional_Header();
 
     // Generate namespace end
     WriteLine();
@@ -1402,7 +1402,7 @@ void GeneratorCpp::GenerateFBECustomModels_Inline(const CppCommon::Path& path)
     GenerateFBEFieldModelCustomArray_Inline();
     GenerateFBEFieldModelCustomVector_Inline();
     GenerateFBEFieldModelCustomMap_Inline();
-    GenerateFBEFieldModelCustomOptional_Inline();
+    GenerateFBEFieldModelStructOptional_Inline();
 
     // Generate namespace end
     WriteLine();
@@ -2351,12 +2351,12 @@ void GeneratorCpp::GeneratePtrStructFieldModel_Header(const std::shared_ptr<Pack
             if (IsStructType(p, field) && !IsKnownType(*field->type)) {
                 std::string model_name = std::string("FieldModel") + (field->ptr ? "Ptr" : "") + "_" + *p->name + "_" + *field->type;
                 if (IsContainerType(*field) || field->optional) {
-                    WriteIndent("FieldModelCustom");
+                    WriteIndent("FieldModel");
                     if (field->array) {
-                        Write("Array<" + model_name + ", " + ConvertPtrTypeName(*p->name, *field->type) + ", " + std::to_string(field->N) + ">");
+                        Write("CustomArray<" + model_name + ", " + ConvertPtrTypeName(*p->name, *field->type) + ", " + std::to_string(field->N) + ">");
                     }
                     else if (field->vector || field->list || field->set)
-                        Write("Vector<" + model_name + ", " + ConvertPtrTypeName(*p->name, *field->type) + ">");
+                        Write("CustomVector<" + model_name + ", " + ConvertPtrTypeName(*p->name, *field->type) + ">");
                     else if (field->map || field->hash){
                         // TODO: specification是可以指定为key的，但是因为StructField的ptr指针对value，所以我们暂且不支持对key支持pointer
                         std::string kType = "FieldModel";
@@ -2367,10 +2367,10 @@ void GeneratorCpp::GeneratePtrStructFieldModel_Header(const std::shared_ptr<Pack
                         }
                         auto kStruct = ConvertPtrTypeName(*p->name, *field->key);
                         auto vStruct = ConvertPtrTypeName(*p->name, *field->type);
-                        Write("Map<" + kType + ", " + model_name + ", " + kStruct  + ", " + vStruct + ">");
+                        Write("CustomMap<" + kType + ", " + model_name + ", " + kStruct  + ", " + vStruct + ">");
                     }
                     else if (field->optional) {
-                        Write("Optional<" + model_name + ", " + ConvertPtrTypeName(*p->name, *field->type) + ">");
+                        Write("StructOptional<" + model_name + ", " + ConvertPtrTypeName(*p->name, *field->type) + ">");
                     }
                     Write(" " +  *field->name + ";");
                     WriteLine();

--- a/source/generator_cpp.inl
+++ b/source/generator_cpp.inl
@@ -102,6 +102,203 @@ public:
     Write(code);
 }
 
+void GeneratorCpp::GenerateFBEFieldModelCustomOptional_Header()
+{
+    std::string code = R"CODE(
+template <typename T, typename TStruct>
+class FieldModelCustomOptional
+{
+public:
+    FieldModelCustomOptional(FBEBuffer& buffer, size_t offset) noexcept: _buffer(buffer), _offset(offset), value(buffer, 0) {}
+
+    // Get the field offset
+    size_t fbe_offset() const noexcept { return _offset; }
+    // Get the field size
+    size_t fbe_size() const noexcept { return 1 + 4; }
+    // Get the field extra size
+    size_t fbe_extra() const noexcept;
+
+    // Shift the current field offset
+    void fbe_shift(size_t size) noexcept { _offset += size; }
+    // Unshift the current field offset
+    void fbe_unshift(size_t size) noexcept { _offset -= size; }
+
+    //! Is the value present?
+    explicit operator bool() const noexcept { return has_value(); }
+
+    // Checks if the object contains a value
+    bool has_value() const noexcept;
+
+    // Check if the optional value is valid
+    bool verify() const noexcept;
+
+    // Get the optional value (being phase)
+    size_t get_begin() const noexcept;
+    // Get the optional value (end phase)
+    void get_end(size_t fbe_begin) const noexcept;
+
+    // Get the optional value
+    void get(std::optional<TStruct>& opt) noexcept;
+
+    // Set the optional value (begin phase)
+    size_t set_begin(bool has_value);
+    // Set the optional value (end phase)
+    void set_end(size_t fbe_begin);
+
+    // Set the optional value
+    void set(const std::optional<TStruct>& opt);
+
+private:
+    FBEBuffer& _buffer;
+    size_t _offset;
+
+public:
+    // Base field model value
+    T value;
+};
+)CODE";
+
+    // Prepare code template
+    code = std::regex_replace(code, std::regex("\n"), EndLine());
+
+    Write(code);
+}
+
+void GeneratorCpp::GenerateFBEFieldModelCustomOptional_Inline()
+{
+    std::string code = R"CODE(
+template <typename T, typename TStruct>
+inline size_t FieldModelCustomOptional<T, TStruct>::fbe_extra() const noexcept
+{
+    if (!has_value())
+        return 0;
+
+    uint32_t fbe_optional_offset = *((const uint32_t*)(_buffer.data() + _buffer.offset() + fbe_offset() + 1));
+    if ((fbe_optional_offset == 0) || ((_buffer.offset() + fbe_optional_offset + 4) > _buffer.size()))
+        return 0;
+
+    _buffer.shift(fbe_optional_offset);
+    size_t fbe_result = value.fbe_size() + value.fbe_extra();
+    _buffer.unshift(fbe_optional_offset);
+    return fbe_result;
+}
+
+template <typename T, typename TStruct>
+inline bool FieldModelCustomOptional<T, TStruct>::has_value() const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return false;
+
+    uint8_t fbe_has_value = *((const uint8_t*)(_buffer.data() + _buffer.offset() + fbe_offset()));
+    return (fbe_has_value != 0);
+}
+
+template <typename T, typename TStruct>
+inline bool FieldModelCustomOptional<T, TStruct>::verify() const noexcept
+{
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return true;
+
+    uint8_t fbe_has_value = *((const uint8_t*)(_buffer.data() + _buffer.offset() + fbe_offset()));
+    if (fbe_has_value == 0)
+        return true;
+
+    uint32_t fbe_optional_offset = *((const uint32_t*)(_buffer.data() + _buffer.offset() + fbe_offset() + 1));
+    if (fbe_optional_offset == 0)
+        return false;
+
+    _buffer.shift(fbe_optional_offset);
+    bool fbe_result = value.verify();
+    _buffer.unshift(fbe_optional_offset);
+    return fbe_result;
+}
+
+template <typename T, typename TStruct>
+inline size_t FieldModelCustomOptional<T, TStruct>::get_begin() const noexcept
+{
+    if (!has_value())
+        return 0;
+
+    uint32_t fbe_optional_offset = *((const uint32_t*)(_buffer.data() + _buffer.offset() + fbe_offset() + 1));
+    assert((fbe_optional_offset > 0) && "Model is broken!");
+    if (fbe_optional_offset == 0)
+        return 0;
+
+    _buffer.shift(fbe_optional_offset);
+    return fbe_optional_offset;
+}
+
+template <typename T, typename TStruct>
+inline void FieldModelCustomOptional<T, TStruct>::get_end(size_t fbe_begin) const noexcept
+{
+    _buffer.unshift(fbe_begin);
+}
+
+template <typename T, typename TStruct>
+inline void FieldModelCustomOptional<T, TStruct>::get(std::optional<TStruct>& opt) noexcept
+{
+
+    size_t fbe_begin = get_begin();
+    if (fbe_begin == 0)
+        return;
+
+    TStruct temp = TStruct();
+    value.get(temp);
+    opt.emplace(std::move(temp));
+
+    get_end(fbe_begin);
+}
+
+template <typename T, typename TStruct>
+inline size_t FieldModelCustomOptional<T, TStruct>::set_begin(bool has_value)
+{
+    assert(((_buffer.offset() + fbe_offset() + fbe_size()) <= _buffer.size()) && "Model is broken!");
+    if ((_buffer.offset() + fbe_offset() + fbe_size()) > _buffer.size())
+        return 0;
+
+    uint8_t fbe_has_value = has_value ? 1 : 0;
+    *((uint8_t*)(_buffer.data() + _buffer.offset() + fbe_offset())) = fbe_has_value;
+    if (fbe_has_value == 0)
+        return 0;
+
+    uint32_t fbe_optional_size = (uint32_t)value.fbe_size();
+    uint32_t fbe_optional_offset = (uint32_t)(_buffer.allocate(fbe_optional_size) - _buffer.offset());
+    assert(((fbe_optional_offset > 0) && ((_buffer.offset() + fbe_optional_offset + fbe_optional_size) <= _buffer.size())) && "Model is broken!");
+    if ((fbe_optional_offset == 0) || ((_buffer.offset() + fbe_optional_offset + fbe_optional_size) > _buffer.size()))
+        return 0;
+
+    *((uint32_t*)(_buffer.data() + _buffer.offset() + fbe_offset() + 1)) = fbe_optional_offset;
+
+    _buffer.shift(fbe_optional_offset);
+    return fbe_optional_offset;
+}
+
+template <typename T, typename TStruct>
+inline void FieldModelCustomOptional<T, TStruct>::set_end(size_t fbe_begin)
+{
+    _buffer.unshift(fbe_begin);
+}
+
+template <typename T, typename TStruct>
+inline void FieldModelCustomOptional<T, TStruct>::set(const std::optional<TStruct>& opt)
+{
+    size_t fbe_begin = set_begin(opt.has_value());
+    if (fbe_begin == 0)
+        return;
+
+    if (opt)
+        value.set(opt.value());
+
+    set_end(fbe_begin);
+}
+)CODE";
+
+    // Prepare code template
+    code = std::regex_replace(code, std::regex("\n"), EndLine());
+
+    Write(code);
+}
+
 void GeneratorCpp::GenerateFBEFieldModelCustomArray_Header()
 {
     std::string code = R"CODE(
@@ -1168,6 +1365,7 @@ void GeneratorCpp::GenerateFBECustomModels_Header(const CppCommon::Path& path)
     GenerateFBEFieldModelCustomArray_Header();
     GenerateFBEFieldModelCustomVector_Header();
     GenerateFBEFieldModelCustomMap_Header();
+    GenerateFBEFieldModelCustomOptional_Header();
 
     // Generate namespace end
     WriteLine();
@@ -1204,6 +1402,7 @@ void GeneratorCpp::GenerateFBECustomModels_Inline(const CppCommon::Path& path)
     GenerateFBEFieldModelCustomArray_Inline();
     GenerateFBEFieldModelCustomVector_Inline();
     GenerateFBEFieldModelCustomMap_Inline();
+    GenerateFBEFieldModelCustomOptional_Inline();
 
     // Generate namespace end
     WriteLine();
@@ -1651,6 +1850,7 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
 
     std::vector<std::string> unique_ptr_members;
     std::vector<std::shared_ptr<StructField>> collection_of_container_ptrs;
+    std::vector<std::shared_ptr<StructField>> collection_of_optional_fields;
     // Generate struct initialization constructor
     if ((s->base && !s->base->empty()) || (s->body && !s->body->fields.empty()))
     {
@@ -1694,6 +1894,9 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
                     }
                 } else if (IsKnownType(*field->type)) {
                     WriteLineIndent(std::string(first ? ": " : ", ") + *field->name + "(arg_" + *field->name + ")");
+                } else if (field->optional) {
+                    collection_of_optional_fields.push_back(field);
+                    WriteLineIndent(std::string(first ? ": " : ", ") + *field->name + "()");
                 } else {
                     WriteLineIndent(std::string(first ? ": " : ", ") + *field->name + "(std::move(arg_" + *field->name + "))");
                 }
@@ -1701,7 +1904,7 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
             }
         }
         Indent(-1);
-        if (collection_of_container_ptrs.empty()) {
+        if (collection_of_container_ptrs.empty() && collection_of_optional_fields.empty()) {
             WriteLineIndent("{}");
         } else {
                 WriteLineIndent("{");
@@ -1724,6 +1927,15 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
                         Indent(-1);
                     }
                 }
+                for (const auto&field : collection_of_optional_fields) {
+                    WriteLineIndent("if (arg_" + *field->name + ".has_value()) {");
+                    Indent(1);
+                    WriteLineIndent("auto&& _v = arg_" + *field->name + ".value();");
+                    WriteLineIndent(*field->name + ".emplace(std::move(_v));");
+                    WriteLineIndent("arg_" + *field->name + ".reset();");
+                    Indent(-1);
+                    WriteLineIndent("}");
+                }
                 Indent(-1);
                 WriteLineIndent("}");
 
@@ -1731,6 +1943,8 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
     }
 
     // Generate struct move constructor
+    collection_of_optional_fields.clear();
+
     WriteLine();
     WriteLineIndent(*s->name + "::" + *s->name + "(" + *s->name + "&& other)");
     Indent(1);
@@ -1753,6 +1967,9 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
                     WriteLineIndent(std::string(first ? ": " : ", ") + *field->name + "(std::exchange(other." + *field->name + ", nullptr))");
             } else if (IsPrimitiveType(*field->type, field->optional)) {
                 WriteLineIndent(std::string(first ? ": " : ", ") + *field->name + "(std::exchange(other." + *field->name + ", " + ConvertDefault(*p->name, *field) + "))");
+            } else if (field->optional)  {
+                collection_of_optional_fields.push_back(field);
+                WriteLineIndent(std::string(first ? ": " : ", ") + *field->name + "()");
             } else {
                 WriteLineIndent(std::string(first ? ": " : ", ") + *field->name + "(std::move(other." + *field->name + "))");
             }
@@ -1760,7 +1977,27 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
         }
     }
     Indent(-1);
-    WriteLineIndent("{}");
+    if (collection_of_optional_fields.empty()) {
+        WriteLineIndent("{}");
+    } else {
+        WriteLineIndent("{");
+        Indent(1);
+        for (const auto&field : collection_of_optional_fields) {
+            WriteLineIndent("if (other." + *field->name + ".has_value()) {");
+            Indent(1);
+            if (IsPrimitiveType(*field->type, false)) {
+                WriteLineIndent(*field->name + ".emplace(other." + *field->name + ".value());");
+            } else {
+                WriteLineIndent("auto&& _v = other." + *field->name + ".value();");
+                WriteLineIndent(*field->name + ".emplace(std::move(_v));");
+            }
+            WriteLineIndent("other." + *field->name + ".reset();");
+            Indent(-1);
+            WriteLineIndent("}");
+        }
+        Indent(-1);
+        WriteLineIndent("}");
+    }
 
 
     WriteLine();
@@ -1891,6 +2128,19 @@ void GeneratorCpp::GeneratePtrStruct_Source(const std::shared_ptr<Package>& p, c
                     WriteLineIndent(*field->name + " = std::exchange(other." + *field->name + ", nullptr);");
             } else if (IsPrimitiveType(*field->type, field->optional)) {
                 WriteLineIndent(*field->name + " = std::exchange(other." + *field->name + ", " + ConvertDefault(*p->name, *field) + ");");
+
+            } else if (field->optional) {
+                WriteLineIndent("if (other." + *field->name + ".has_value()) {");
+                Indent(1);
+                if (IsPrimitiveType(*field->type, false)) {
+                    WriteLineIndent(*field->name + ".emplace(other." + *field->name + ".value());");
+                } else {
+                    WriteLineIndent("auto&& _v = other." + *field->name + ".value();");
+                    WriteLineIndent(*field->name + ".emplace(std::move(_v));");
+                }
+                WriteLineIndent("other." + *field->name + ".reset();");
+                Indent(-1);
+                WriteLineIndent("}");
             } else {
                 WriteLineIndent(*field->name + " = std::move(other." + *field->name + ");");
             }
@@ -2100,7 +2350,7 @@ void GeneratorCpp::GeneratePtrStructFieldModel_Header(const std::shared_ptr<Pack
             // Struct
             if (IsStructType(p, field) && !IsKnownType(*field->type)) {
                 std::string model_name = std::string("FieldModel") + (field->ptr ? "Ptr" : "") + "_" + *p->name + "_" + *field->type;
-                if (IsContainerType(*field)) {
+                if (IsContainerType(*field) || field->optional) {
                     WriteIndent("FieldModelCustom");
                     if (field->array) {
                         Write("Array<" + model_name + ", " + ConvertPtrTypeName(*p->name, *field->type) + ", " + std::to_string(field->N) + ">");
@@ -2118,6 +2368,9 @@ void GeneratorCpp::GeneratePtrStructFieldModel_Header(const std::shared_ptr<Pack
                         auto kStruct = ConvertPtrTypeName(*p->name, *field->key);
                         auto vStruct = ConvertPtrTypeName(*p->name, *field->type);
                         Write("Map<" + kType + ", " + model_name + ", " + kStruct  + ", " + vStruct + ">");
+                    }
+                    else if (field->optional) {
+                        Write("Optional<" + model_name + ", " + ConvertPtrTypeName(*p->name, *field->type) + ">");
                     }
                     Write(" " +  *field->name + ";");
                     WriteLine();
@@ -2477,8 +2730,7 @@ void GeneratorCpp::GeneratePtrStructFieldModel_Source(const std::shared_ptr<Pack
         if (s->body)
             for (const auto& field : s->body->fields)
             {
-                if (IsStructType(p, field) && !field->ptr && !IsContainerType(*field))
-                    // TODO: fix enum and flags
+                if (IsStructType(p, field) && !field->ptr && !IsContainerType(*field) && !field->optional)
                     WriteLineIndent(*field->name + ".set(static_cast<const ::" + *p->name + "::" + *field->type + "&>(" + "fbe_value." + *field->name + "));");
                 else
                     WriteLineIndent(*field->name + ".set(fbe_value." + *field->name + ");");


### PR DESCRIPTION
此次改动之前std::optional对于enums、flags是好使的，因为enums和flags都是基于template的。为了让struct也支持optional，我们使用了和支持container一致的方式，即引入一个`FieldModelCustomOptional`的template, 这样struct也就可以使用optional了

对于optional的处理我觉得可能还是有些问题。目前的做法:
- cstr: 主要是处理ptr-based struct，对value进行move。同时会进行reset操作。因为可能内部会包含raw pointer
- move cstr: 需要对所有的optional进行reset.

为了便于review，本pr没有fbe生成的文件。