### PR TITLE
fix memcpy from null pointer

### DIFF
--- a/proto/fbe.cpp
+++ b/proto/fbe.cpp
@@ -347,8 +347,11 @@ size_t FBEBuffer::allocate(size_t size)
 
     _capacity = std::max(total, 2 * _capacity);
     uint8_t* data = (uint8_t*)std::malloc(_capacity);
-    std::memcpy(data, _data, _size);
-    std::free(_data);
+    if (_data != nullptr)
+    {
+        std::memcpy(data, _data, _size);
+        std::free(_data);
+    }
     _data = data;
     _size = total;
     return offset;

--- a/source/generator_cpp.cpp
+++ b/source/generator_cpp.cpp
@@ -1319,8 +1319,11 @@ size_t FBEBuffer::allocate(size_t size)
 
     _capacity = std::max(total, 2 * _capacity);
     uint8_t* data = (uint8_t*)std::malloc(_capacity);
-    std::memcpy(data, _data, _size);
-    std::free(_data);
+    if (_data != nullptr)
+    {
+        std::memcpy(data, _data, _size);
+        std::free(_data);
+    }
     _data = data;
     _size = total;
     return offset;


### PR DESCRIPTION
If `_data` is a null pointer, the behavior is undefined and It will fail the ASans checks