### PR TITLE
FBE format support variant

### DIFF
--- a/include/fbe.h
+++ b/include/fbe.h
@@ -96,6 +96,27 @@ struct FlagsType
     std::shared_ptr<FlagsBody> body;
 };
 
+struct VariantValue
+{
+    std::shared_ptr<std::string> type;
+    bool ptr{false};
+};
+
+struct VariantBody
+{
+    std::vector<std::shared_ptr<VariantValue>> values;
+
+    void AddValue(VariantValue* v);
+};
+
+
+struct VariantType
+{
+    std::shared_ptr<Attributes> attributes;
+    std::shared_ptr<std::string> name;
+    std::shared_ptr<VariantBody> body;
+};
+
 struct StructField
 {
     std::shared_ptr<Attributes> attributes;
@@ -114,6 +135,7 @@ struct StructField
     bool map{false};
     bool hash{false};
     bool ptr{false};
+    bool variant{false};
     int N{0};
 
     void SetArraySize(int size);
@@ -172,6 +194,7 @@ struct Statement
 {
     std::shared_ptr<EnumType> e;
     std::shared_ptr<FlagsType> f;
+    std::shared_ptr<VariantType> v;
     std::shared_ptr<StructType> s;
 };
 
@@ -179,6 +202,7 @@ struct Statements
 {
     std::vector<std::shared_ptr<EnumType>> enums;
     std::vector<std::shared_ptr<FlagsType>> flags;
+    std::vector<std::shared_ptr<VariantType>> variants;
     std::vector<std::shared_ptr<StructType>> structs;
 
     void AddStatement(Statement* st);
@@ -186,6 +210,7 @@ struct Statements
     void AddEnum(std::shared_ptr<EnumType>& e);
     void AddFlags(std::shared_ptr<FlagsType>& f);
     void AddStruct(std::shared_ptr<StructType>& s);
+    void AddVariant(std::shared_ptr<VariantType>& v);
 };
 
 struct Import

--- a/source/fbe.cpp
+++ b/source/fbe.cpp
@@ -48,6 +48,21 @@ void FlagsBody::AddValue(FlagsValue* v)
     values.push_back(std::shared_ptr<FlagsValue>(v));
 }
 
+void VariantBody::AddValue(VariantValue* v)
+{
+    if (v == nullptr)
+        yyerror("Variant is null!");
+    if (v->type->empty())
+        yyerror("Variant type is invalid!");
+
+    // Check for duplicates
+    auto it = std::find_if(values.begin(), values.end(), [v](auto item)->bool { return *item->type.get() == *v->type.get() && item->ptr == v->ptr; });
+    if (it != values.end())
+        yyerror("Duplicate Variant type " + *v->type.get());
+
+    values.push_back(std::shared_ptr<VariantValue>(v));
+}
+
 void StructField::SetArraySize(int size)
 {
     if (size <= 0)
@@ -115,7 +130,8 @@ void Statements::AddStatement(Statement* st)
         AddFlags(st->f);
     if (st->s)
         AddStruct(st->s);
-
+    if (st->v)
+        AddVariant(st->v);
     delete st;
 }
 
@@ -151,6 +167,23 @@ void Statements::AddFlags(std::shared_ptr<FlagsType>& f)
         yyerror("Duplicate flags name " + *f->name.get());
 
     flags.push_back(f);
+}
+
+void Statements::AddVariant(std::shared_ptr<VariantType> &v)
+{
+    if (v == nullptr)
+        yyerror("Variant is null!");
+    if (v->name->empty())
+        yyerror("Variant name is invalid!");
+    if (!v->body)
+        yyerror("Variant is empty - " + *v->name.get());
+
+    // Check for duplicates
+    auto it = std::find_if(variants.begin(), variants.end(), [&v](auto item)->bool { return *item->name.get() == *v->name.get(); });
+    if (it != variants.end())
+        yyerror("Duplicate variant name " + *v->name.get());
+
+    variants.push_back(v);
 }
 
 void Statements::AddStruct(std::shared_ptr<StructType>& s)

--- a/source/fbe.l
+++ b/source/fbe.l
@@ -45,6 +45,7 @@ int yyerror(const std::string& msg);
 "version"               { yycount(); return yytoken(VERSION); }
 "enum"                  { yycount(); return yytoken(ENUM); }
 "flags"                 { yycount(); return yytoken(FLAGS); }
+"variant"               { yycount(); return yytoken(VARIANT); }
 "struct"                { yycount(); return yytoken(STRUCT); }
 "message"               { yycount(); return yytoken(MESSAGE); }
 "base"                  { yycount(); return yytoken(BASE); }

--- a/source/fbe.y
+++ b/source/fbe.y
@@ -32,6 +32,9 @@ int yyerror(const std::string& msg);
     FBE::FlagsBody* flags_body;
     FBE::FlagsValue* flags_value;
     FBE::FlagsConst* flags_const;
+    FBE::VariantValue* variant_value;
+    FBE::VariantType* variant_type;
+    FBE::VariantBody* variant_body;
     FBE::StructType* struct_type;
     FBE::StructRequest* struct_request;
     FBE::StructResponse* struct_response;
@@ -41,7 +44,7 @@ int yyerror(const std::string& msg);
 }
 
 // Define our terminal symbols (tokens)
-%token <token>  PDOMAIN PACKAGE OFFSET IMPORT VERSION ENUM FLAGS STRUCT MESSAGE BASE ID KEY HIDDEN DEPRECATED REQ RES REJ
+%token <token>  PDOMAIN PACKAGE OFFSET IMPORT VERSION ENUM FLAGS VARIANT STRUCT MESSAGE BASE ID KEY HIDDEN DEPRECATED REQ RES REJ
 %token <string> BOOL BYTE BYTES CHAR WCHAR INT8 UINT8 INT16 UINT16 INT32 UINT32 INT64 UINT64 FLOAT DOUBLE DECIMAL STRING USTRING TIMESTAMP UUID
 %token <string> CONST_TRUE CONST_FALSE CONST_NULL CONST_EPOCH CONST_UTC CONST_UUID0 CONST_UUID1 CONST_UUID4 CONST_CHAR CONST_INT CONST_FLOAT CONST_STRING
 %token <string> IDENTIFIER
@@ -66,6 +69,11 @@ int yyerror(const std::string& msg);
 %type <flags_body> flags_body
 %type <flags_value> flags_value
 %type <flags_const> flags_const
+%type <variant_type> variant
+%type <variant_body> variant_body
+%type <variant_value> variant_value
+%type <variant_value> variant_value_base
+%type <variant_value> variant_value_base_ptr
 %type <struct_type> struct
 %type <boolean> struct_type
 %type <struct_request> struct_request
@@ -131,6 +139,7 @@ statements
 statement
     : enum                                                                                  { $$ = new FBE::Statement(); $$->e.reset($1); }
     | flags                                                                                 { $$ = new FBE::Statement(); $$->f.reset($1); }
+    | variant                                                                               { $$ = new FBE::Statement(); $$->v.reset($1); }
     | struct                                                                                { $$ = new FBE::Statement(); $$->s.reset($1); }
     | struct_request struct_response struct_rejects struct                                  { $$ = new FBE::Statement(); $$->s.reset($4); $$->s->request.reset($1); $$->s->response.reset($2); $$->s->rejects.reset($3); }
     ;
@@ -169,6 +178,7 @@ enum_body
     :                                                                                       { $$ = new FBE::EnumBody(); }
     | enum_value                                                                            { $$ = new FBE::EnumBody(); $$->AddValue($1); }
     | enum_body enum_value                                                                  { $$ = $1; $$->AddValue($2); }
+    ;
 
 enum_value
     : attributes name ';'                                                                   { $$ = new FBE::EnumValue(); $$->attributes.reset($1); $$->name.reset($2); }
@@ -179,6 +189,46 @@ enum_const
     : CONST_CHAR                                                                            { $$ = new FBE::EnumConst(); $$->constant.reset($1); }
     | CONST_INT                                                                             { $$ = new FBE::EnumConst(); $$->constant.reset($1); }
     | name                                                                                  { $$ = new FBE::EnumConst(); $$->reference.reset($1); }
+    ;
+
+variant
+    : attributes VARIANT name '{' variant_body '}'                                          { $$ = new FBE::VariantType(); $$->attributes.reset($1); $$->name.reset($3); $$->body.reset($5); }
+
+variant_body
+    : variant_value                                                                         { $$ = new FBE::VariantBody(); $$->AddValue($1); }
+    | variant_body variant_value                                                            { $$ = $1; $$->AddValue($2); }
+    ;
+
+variant_value
+    : variant_value_base ';'
+    | variant_value_base_ptr ';'
+    ;
+
+variant_value_base
+    : BOOL                                                                                  { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | BYTE                                                                                  { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | BYTES                                                                                 { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | CHAR                                                                                  { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | WCHAR                                                                                 { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | INT8                                                                                  { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | UINT8                                                                                 { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | INT16                                                                                 { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | UINT16                                                                                { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | INT32                                                                                 { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | UINT32                                                                                { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | INT64                                                                                 { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | UINT64                                                                                { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | FLOAT                                                                                 { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | DOUBLE                                                                                { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | DECIMAL                                                                               { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | STRING                                                                                { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | TIMESTAMP                                                                             { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | UUID                                                                                  { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    | type_name                                                                             { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    ;
+
+variant_value_base_ptr                                                                       
+    : type_name '*'                                                                         { $$ = new FBE::VariantValue(); $$->type.reset($1); $$->ptr = true; }
     ;
 
 flags


### PR DESCRIPTION
This PR makes FBE support variant syntax below:
```
struct Date {
  int16 year;
  uint8 month;
  uint8 day;
}

variant Scalar {
  bool;
  string;
  Date;
  Date*;   // ptr-based only
}

struct Set {
  Scalar s;
  Scalar? so;
  Scalar[] sv;
  Scalar<int> sm;
}
```

And variant does not support container and optional yet.