### PR TITLE
Variant support collection types

### DIFF
--- a/include/fbe.h
+++ b/include/fbe.h
@@ -105,6 +105,19 @@ struct VariantValue
     bool list{false};
     bool map{false};
     bool hash{false};
+
+    bool operator==(const VariantValue& other) const noexcept
+    {
+        return (
+            ((key && other.key && *key == *other.key) || (key == nullptr && other.key == nullptr)) && 
+            *type == *other.type &&
+            ptr == other.ptr &&
+            vector == other.vector &&
+            list == other.list &&
+            map == other.map &&
+            hash == other.hash
+        );
+    }
 };
 
 struct VariantBody

--- a/include/fbe.h
+++ b/include/fbe.h
@@ -98,8 +98,13 @@ struct FlagsType
 
 struct VariantValue
 {
+    std::shared_ptr<std::string> key;
     std::shared_ptr<std::string> type;
     bool ptr{false};
+    bool vector{false};
+    bool list{false};
+    bool map{false};
+    bool hash{false};
 };
 
 struct VariantBody

--- a/include/generator_cpp.h
+++ b/include/generator_cpp.h
@@ -220,11 +220,13 @@ private:
 
     bool IsKnownType(const std::string& type);
     bool IsPrimitiveType(const std::string& type, bool optional);
-    bool IsContainerType(const StructField &field);
+    bool IsContainerType(const StructField& field);
+    bool IsContainerType(const VariantValue& variant);
     bool IsStructType(const std::shared_ptr<Package>& p, const std::string& field_type);
     bool IsVariantType(const std::shared_ptr<Package>& p, const std::string& type);
 
     std::string ConvertVariantTypeName(const std::string& package, const VariantValue& variant);
+    std::string ConvertVariantTypeNameAsArgument(const std::string& package, const VariantValue& variant);
     std::string ConvertPtrFieldModelType(const std::shared_ptr<Package>& p, const std::shared_ptr<StructField>& field);
     std::string ConvertPtrVariantFieldModelType(const std::shared_ptr<Package>& p, const std::shared_ptr<VariantValue>& variant);
     std::string ConvertEnumType(const std::string& type);

--- a/include/generator_cpp.h
+++ b/include/generator_cpp.h
@@ -224,6 +224,7 @@ private:
     bool IsStructType(const std::shared_ptr<Package>& p, const std::string& field_type);
     bool IsVariantType(const std::shared_ptr<Package>& p, const std::string& type);
 
+    std::string ConvertVariantTypeName(const std::string& package, const VariantValue& variant);
     std::string ConvertPtrFieldModelType(const std::shared_ptr<Package>& p, const std::shared_ptr<StructField>& field);
     std::string ConvertPtrVariantFieldModelType(const std::shared_ptr<Package>& p, const std::shared_ptr<VariantValue>& variant);
     std::string ConvertEnumType(const std::string& type);

--- a/proto/variants.cpp
+++ b/proto/variants.cpp
@@ -16,6 +16,7 @@ std::ostream& operator<<(std::ostream& stream, const V& value)
             , [&stream](int32_t v) { stream << v; }
             , [&stream](double v) { stream << v; }
             , [&stream](const ::variants::Simple& v) { stream << v; }
+            , [&stream](auto&) { stream << "unknown type"; },
         },
         value);
     return stream;
@@ -28,6 +29,7 @@ std::ostream& operator<<(std::ostream& stream, const Expr& value)
         {
             [&stream](bool v) { stream << v; }
             , [&stream](int32_t v) { stream << v; }
+            , [&stream](auto&) { stream << "unknown type"; },
         },
         value);
     return stream;

--- a/proto/variants.fbe
+++ b/proto/variants.fbe
@@ -10,6 +10,9 @@ variant V {
   int32;
   double;
   Simple;
+  Simple[];
+  int32[];
+  Simple{int32};
 }
 
 variant Expr {

--- a/proto/variants.fbe
+++ b/proto/variants.fbe
@@ -13,6 +13,10 @@ variant V {
   Simple[];
   int32[];
   Simple{int32};
+  bytes[];
+  string[];
+  bytes{int32};
+  bytes{string};
 }
 
 variant Expr {

--- a/proto/variants.h
+++ b/proto/variants.h
@@ -32,7 +32,7 @@ namespace variants {
 struct Simple;
 struct Value;
 
-using V = std::variant<std::string, int32_t, double, ::variants::Simple>;
+using V = std::variant<std::string, int32_t, double, ::variants::Simple, std::vector<::variants::Simple>, std::vector<int32_t>, std::unordered_map<int32_t, ::variants::Simple>>;
 std::ostream& operator<<(std::ostream& stream, const V& value);
 
 using Expr = std::variant<bool, int32_t>;

--- a/proto/variants.h
+++ b/proto/variants.h
@@ -32,7 +32,7 @@ namespace variants {
 struct Simple;
 struct Value;
 
-using V = std::variant<std::string, int32_t, double, ::variants::Simple, std::vector<::variants::Simple>, std::vector<int32_t>, std::unordered_map<int32_t, ::variants::Simple>>;
+using V = std::variant<std::string, int32_t, double, ::variants::Simple, std::vector<::variants::Simple>, std::vector<int32_t>, std::unordered_map<int32_t, ::variants::Simple>, std::vector<FBE::buffer_t>, std::vector<std::string>, std::unordered_map<int32_t, FBE::buffer_t>, std::unordered_map<std::string, FBE::buffer_t>>;
 std::ostream& operator<<(std::ostream& stream, const V& value);
 
 using Expr = std::variant<bool, int32_t>;

--- a/proto/variants_models.cpp
+++ b/proto/variants_models.cpp
@@ -45,7 +45,7 @@ bool FieldModelVariant_variants_V::verify() const noexcept
         return false;
 
     uint32_t fbe_variant_type = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_variant_offset);
-    if (fbe_variant_type < 0 || fbe_variant_type >= 4)
+    if (fbe_variant_type < 0 || fbe_variant_type >= 7)
         return false;
 
     _buffer.shift(fbe_variant_offset);
@@ -74,6 +74,24 @@ bool FieldModelVariant_variants_V::verify() const noexcept
                 return false;
             break;
         }
+        case 4: {
+            FieldModelVector<::variants::Simple> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
+        case 5: {
+            FieldModelVector<int32_t> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
+        case 6: {
+            FieldModelMap<int32_t, ::variants::Simple> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
     }
 
     _buffer.unshift(fbe_variant_offset);
@@ -90,7 +108,7 @@ void FieldModelVariant_variants_V::get(::variants::V& fbe_value) const noexcept
     if ((fbe_variant_offset == 0) || ((_buffer.offset() + fbe_variant_offset + 4) > _buffer.size()))
         return;
     uint32_t vairant_type_index = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_variant_offset);
-    assert(vairant_type_index >= 0 && vairant_type_index < 4 && "Model is broken!");
+    assert(vairant_type_index >= 0 && vairant_type_index < 7 && "Model is broken!");
 
     _buffer.shift(fbe_variant_offset);
 
@@ -98,28 +116,49 @@ void FieldModelVariant_variants_V::get(::variants::V& fbe_value) const noexcept
         case 0: {
             FieldModel<std::string> fbe_model(_buffer, 4);
             fbe_value.emplace<std::string>();
-            auto& value = std::get<std::string>(fbe_value);
+            auto& value = std::get<0>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 1: {
             FieldModel<int32_t> fbe_model(_buffer, 4);
             fbe_value.emplace<int32_t>();
-            auto& value = std::get<int32_t>(fbe_value);
+            auto& value = std::get<1>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 2: {
             FieldModel<double> fbe_model(_buffer, 4);
             fbe_value.emplace<double>();
-            auto& value = std::get<double>(fbe_value);
+            auto& value = std::get<2>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 3: {
             FieldModel<::variants::Simple> fbe_model(_buffer, 4);
             fbe_value.emplace<::variants::Simple>();
-            auto& value = std::get<::variants::Simple>(fbe_value);
+            auto& value = std::get<3>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 4: {
+            FieldModelVector<::variants::Simple> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::vector<::variants::Simple>>();
+            auto& value = std::get<4>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 5: {
+            FieldModelVector<int32_t> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::vector<int32_t>>();
+            auto& value = std::get<5>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 6: {
+            FieldModelMap<int32_t, ::variants::Simple> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::unordered_map<int32_t, ::variants::Simple>>();
+            auto& value = std::get<6>(fbe_value);
             fbe_model.get(value);
             break;
         }
@@ -162,33 +201,57 @@ void FieldModelVariant_variants_V::set(const ::variants::V& fbe_value) noexcept
     std::visit(
         overloaded
         {
-            [this, &fbe_value](const std::string& v) {
+            [this, fbe_variant_index = fbe_value.index()](const std::string& v) {
                 FieldModel<std::string> fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, &fbe_value](int32_t v) {
+            , [this, fbe_variant_index = fbe_value.index()](int32_t v) {
                 FieldModel<int32_t> fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, &fbe_value](double v) {
+            , [this, fbe_variant_index = fbe_value.index()](double v) {
                 FieldModel<double> fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, &fbe_value](const ::variants::Simple& v) {
+            , [this, fbe_variant_index = fbe_value.index()](const ::variants::Simple& v) {
                 FieldModel<::variants::Simple> fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::vector<::variants::Simple>& v) {
+                FieldModelVector<::variants::Simple> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::vector<int32_t>& v) {
+                FieldModelVector<int32_t> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::unordered_map<int32_t, ::variants::Simple>& v) {
+                FieldModelMap<int32_t, ::variants::Simple> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);
@@ -279,14 +342,14 @@ void FieldModelVariant_variants_Expr::get(::variants::Expr& fbe_value) const noe
         case 0: {
             FieldModel<bool> fbe_model(_buffer, 4);
             fbe_value.emplace<bool>();
-            auto& value = std::get<bool>(fbe_value);
+            auto& value = std::get<0>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 1: {
             FieldModel<int32_t> fbe_model(_buffer, 4);
             fbe_value.emplace<int32_t>();
-            auto& value = std::get<int32_t>(fbe_value);
+            auto& value = std::get<1>(fbe_value);
             fbe_model.get(value);
             break;
         }
@@ -329,17 +392,17 @@ void FieldModelVariant_variants_Expr::set(const ::variants::Expr& fbe_value) noe
     std::visit(
         overloaded
         {
-            [this, &fbe_value](bool v) {
+            [this, fbe_variant_index = fbe_value.index()](bool v) {
                 FieldModel<bool> fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, &fbe_value](int32_t v) {
+            , [this, fbe_variant_index = fbe_value.index()](int32_t v) {
                 FieldModel<int32_t> fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);

--- a/proto/variants_models.cpp
+++ b/proto/variants_models.cpp
@@ -45,7 +45,7 @@ bool FieldModelVariant_variants_V::verify() const noexcept
         return false;
 
     uint32_t fbe_variant_type = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_variant_offset);
-    if (fbe_variant_type < 0 || fbe_variant_type >= 7)
+    if (fbe_variant_type < 0 || fbe_variant_type >= 11)
         return false;
 
     _buffer.shift(fbe_variant_offset);
@@ -92,6 +92,30 @@ bool FieldModelVariant_variants_V::verify() const noexcept
                 return false;
             break;
         }
+        case 7: {
+            FieldModelVector<FBE::buffer_t> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
+        case 8: {
+            FieldModelVector<std::string> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
+        case 9: {
+            FieldModelMap<int32_t, FBE::buffer_t> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
+        case 10: {
+            FieldModelMap<std::string, FBE::buffer_t> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
     }
 
     _buffer.unshift(fbe_variant_offset);
@@ -108,7 +132,7 @@ void FieldModelVariant_variants_V::get(::variants::V& fbe_value) const noexcept
     if ((fbe_variant_offset == 0) || ((_buffer.offset() + fbe_variant_offset + 4) > _buffer.size()))
         return;
     uint32_t vairant_type_index = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_variant_offset);
-    assert(vairant_type_index >= 0 && vairant_type_index < 7 && "Model is broken!");
+    assert(vairant_type_index >= 0 && vairant_type_index < 11 && "Model is broken!");
 
     _buffer.shift(fbe_variant_offset);
 
@@ -159,6 +183,34 @@ void FieldModelVariant_variants_V::get(::variants::V& fbe_value) const noexcept
             FieldModelMap<int32_t, ::variants::Simple> fbe_model(_buffer, 4);
             fbe_value.emplace<std::unordered_map<int32_t, ::variants::Simple>>();
             auto& value = std::get<6>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 7: {
+            FieldModelVector<FBE::buffer_t> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::vector<FBE::buffer_t>>();
+            auto& value = std::get<7>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 8: {
+            FieldModelVector<std::string> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::vector<std::string>>();
+            auto& value = std::get<8>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 9: {
+            FieldModelMap<int32_t, FBE::buffer_t> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::unordered_map<int32_t, FBE::buffer_t>>();
+            auto& value = std::get<9>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 10: {
+            FieldModelMap<std::string, FBE::buffer_t> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::unordered_map<std::string, FBE::buffer_t>>();
+            auto& value = std::get<10>(fbe_value);
             fbe_model.get(value);
             break;
         }
@@ -251,6 +303,38 @@ void FieldModelVariant_variants_V::set(const ::variants::V& fbe_value) noexcept
             }
             , [this, fbe_variant_index = fbe_value.index()](const std::unordered_map<int32_t, ::variants::Simple>& v) {
                 FieldModelMap<int32_t, ::variants::Simple> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::vector<FBE::buffer_t>& v) {
+                FieldModelVector<FBE::buffer_t> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::vector<std::string>& v) {
+                FieldModelVector<std::string> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::unordered_map<int32_t, FBE::buffer_t>& v) {
+                FieldModelMap<int32_t, FBE::buffer_t> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::unordered_map<std::string, FBE::buffer_t>& v) {
+                FieldModelMap<std::string, FBE::buffer_t> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;

--- a/proto/variants_ptr_ptr.cpp
+++ b/proto/variants_ptr_ptr.cpp
@@ -16,7 +16,7 @@ std::ostream& operator<<(std::ostream& stream, const V& value)
             , [&stream](int32_t v) { stream << v; }
             , [&stream](double v) { stream << v; }
             , [&stream](const ::variants_ptr::Simple& v) { stream << v; }
-            , [&stream](::variants_ptr::Simple* v) { stream << *v; }
+            , [&stream](auto&) { stream << "unknown type"; },
         },
         value);
     return stream;
@@ -29,6 +29,7 @@ std::ostream& operator<<(std::ostream& stream, const Expr& value)
         {
             [&stream](bool v) { stream << v; }
             , [&stream](int32_t v) { stream << v; }
+            , [&stream](auto&) { stream << "unknown type"; },
         },
         value);
     return stream;

--- a/proto/variants_ptr_ptr.h
+++ b/proto/variants_ptr_ptr.h
@@ -34,7 +34,7 @@ namespace variants_ptr {
 struct Simple;
 struct Value;
 
-using V = std::variant<std::string, int32_t, double, ::variants_ptr::Simple, ::variants_ptr::Simple*, std::vector<::variants_ptr::Simple>, std::vector<int32_t>, std::unordered_map<int32_t, ::variants_ptr::Simple>, std::vector<FBE::buffer_t>, std::vector<std::string>, std::unordered_map<int32_t, FBE::buffer_t>, std::unordered_map<std::string, FBE::buffer_t>>;
+using V = std::variant<std::string, int32_t, double, ::variants_ptr::Simple, ::variants_ptr::Simple*, std::vector<::variants_ptr::Simple>, std::vector<int32_t>, std::unordered_map<int32_t, ::variants_ptr::Simple>, std::vector<FBE::buffer_t>, std::vector<std::string>, std::unordered_map<int32_t, FBE::buffer_t>, std::unordered_map<std::string, FBE::buffer_t>, std::vector<::variants_ptr::Simple*>>;
 std::ostream& operator<<(std::ostream& stream, const V& value);
 
 using Expr = std::variant<bool, int32_t>;

--- a/proto/variants_ptr_ptr.h
+++ b/proto/variants_ptr_ptr.h
@@ -34,7 +34,7 @@ namespace variants_ptr {
 struct Simple;
 struct Value;
 
-using V = std::variant<std::string, int32_t, double, ::variants_ptr::Simple, ::variants_ptr::Simple*>;
+using V = std::variant<std::string, int32_t, double, ::variants_ptr::Simple, ::variants_ptr::Simple*, std::vector<::variants_ptr::Simple>, std::vector<int32_t>, std::unordered_map<int32_t, ::variants_ptr::Simple>>;
 std::ostream& operator<<(std::ostream& stream, const V& value);
 
 using Expr = std::variant<bool, int32_t>;

--- a/proto/variants_ptr_ptr.h
+++ b/proto/variants_ptr_ptr.h
@@ -34,7 +34,7 @@ namespace variants_ptr {
 struct Simple;
 struct Value;
 
-using V = std::variant<std::string, int32_t, double, ::variants_ptr::Simple, ::variants_ptr::Simple*, std::vector<::variants_ptr::Simple>, std::vector<int32_t>, std::unordered_map<int32_t, ::variants_ptr::Simple>>;
+using V = std::variant<std::string, int32_t, double, ::variants_ptr::Simple, ::variants_ptr::Simple*, std::vector<::variants_ptr::Simple>, std::vector<int32_t>, std::unordered_map<int32_t, ::variants_ptr::Simple>, std::vector<FBE::buffer_t>, std::vector<std::string>, std::unordered_map<int32_t, FBE::buffer_t>, std::unordered_map<std::string, FBE::buffer_t>>;
 std::ostream& operator<<(std::ostream& stream, const V& value);
 
 using Expr = std::variant<bool, int32_t>;

--- a/proto/variants_ptr_ptr_models.cpp
+++ b/proto/variants_ptr_ptr_models.cpp
@@ -45,7 +45,7 @@ bool FieldModelVariant_variants_ptr_V::verify() const noexcept
         return false;
 
     uint32_t fbe_variant_type = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_variant_offset);
-    if (fbe_variant_type < 0 || fbe_variant_type >= 5)
+    if (fbe_variant_type < 0 || fbe_variant_type >= 8)
         return false;
 
     _buffer.shift(fbe_variant_offset);
@@ -80,6 +80,24 @@ bool FieldModelVariant_variants_ptr_V::verify() const noexcept
                 return false;
             break;
         }
+        case 5: {
+            FieldModelCustomVector<FieldModel_variants_ptr_Simple, ::variants_ptr::Simple> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
+        case 6: {
+            FieldModelVector<int32_t> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
+        case 7: {
+            FieldModelCustomMap<FieldModel<int32_t>, FieldModel_variants_ptr_Simple, int32_t, ::variants_ptr::Simple> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
     }
 
     _buffer.unshift(fbe_variant_offset);
@@ -96,7 +114,7 @@ void FieldModelVariant_variants_ptr_V::get(::variants_ptr::V& fbe_value) const n
     if ((fbe_variant_offset == 0) || ((_buffer.offset() + fbe_variant_offset + 4) > _buffer.size()))
         return;
     uint32_t vairant_type_index = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_variant_offset);
-    assert(vairant_type_index >= 0 && vairant_type_index < 5 && "Model is broken!");
+    assert(vairant_type_index >= 0 && vairant_type_index < 8 && "Model is broken!");
 
     _buffer.shift(fbe_variant_offset);
 
@@ -134,6 +152,27 @@ void FieldModelVariant_variants_ptr_V::get(::variants_ptr::V& fbe_value) const n
             fbe_value.emplace<::variants_ptr::Simple*>();
             auto& value = std::get<4>(fbe_value);
             fbe_model.get(&value);
+            break;
+        }
+        case 5: {
+            FieldModelCustomVector<FieldModel_variants_ptr_Simple, ::variants_ptr::Simple> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::vector<::variants_ptr::Simple>>();
+            auto& value = std::get<5>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 6: {
+            FieldModelVector<int32_t> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::vector<int32_t>>();
+            auto& value = std::get<6>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 7: {
+            FieldModelCustomMap<FieldModel<int32_t>, FieldModel_variants_ptr_Simple, int32_t, ::variants_ptr::Simple> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::unordered_map<int32_t, ::variants_ptr::Simple>>();
+            auto& value = std::get<7>(fbe_value);
+            fbe_model.get(value);
             break;
         }
     }
@@ -209,6 +248,30 @@ void FieldModelVariant_variants_ptr_V::set(const ::variants_ptr::V& fbe_value) n
             }
             , [this, fbe_variant_index = fbe_value.index()](const ::variants_ptr::Simple* v) {
                 FieldModelPtr_variants_ptr_Simple fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::vector<::variants_ptr::Simple>& v) {
+                FieldModelCustomVector<FieldModel_variants_ptr_Simple, ::variants_ptr::Simple> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::vector<int32_t>& v) {
+                FieldModelVector<int32_t> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::unordered_map<int32_t, ::variants_ptr::Simple>& v) {
+                FieldModelCustomMap<FieldModel<int32_t>, FieldModel_variants_ptr_Simple, int32_t, ::variants_ptr::Simple> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;

--- a/proto/variants_ptr_ptr_models.cpp
+++ b/proto/variants_ptr_ptr_models.cpp
@@ -45,7 +45,7 @@ bool FieldModelVariant_variants_ptr_V::verify() const noexcept
         return false;
 
     uint32_t fbe_variant_type = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_variant_offset);
-    if (fbe_variant_type < 0 || fbe_variant_type >= 8)
+    if (fbe_variant_type < 0 || fbe_variant_type >= 12)
         return false;
 
     _buffer.shift(fbe_variant_offset);
@@ -98,6 +98,30 @@ bool FieldModelVariant_variants_ptr_V::verify() const noexcept
                 return false;
             break;
         }
+        case 8: {
+            FieldModelVector<FBE::buffer_t> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
+        case 9: {
+            FieldModelVector<std::string> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
+        case 10: {
+            FieldModelMap<int32_t, FBE::buffer_t> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
+        case 11: {
+            FieldModelMap<std::string, FBE::buffer_t> fbe_model(_buffer, 4);
+            if (!fbe_model.verify())
+                return false;
+            break;
+        }
     }
 
     _buffer.unshift(fbe_variant_offset);
@@ -114,7 +138,7 @@ void FieldModelVariant_variants_ptr_V::get(::variants_ptr::V& fbe_value) const n
     if ((fbe_variant_offset == 0) || ((_buffer.offset() + fbe_variant_offset + 4) > _buffer.size()))
         return;
     uint32_t vairant_type_index = unaligned_load<uint32_t>(_buffer.data() + _buffer.offset() + fbe_variant_offset);
-    assert(vairant_type_index >= 0 && vairant_type_index < 8 && "Model is broken!");
+    assert(vairant_type_index >= 0 && vairant_type_index < 12 && "Model is broken!");
 
     _buffer.shift(fbe_variant_offset);
 
@@ -172,6 +196,34 @@ void FieldModelVariant_variants_ptr_V::get(::variants_ptr::V& fbe_value) const n
             FieldModelCustomMap<FieldModel<int32_t>, FieldModel_variants_ptr_Simple, int32_t, ::variants_ptr::Simple> fbe_model(_buffer, 4);
             fbe_value.emplace<std::unordered_map<int32_t, ::variants_ptr::Simple>>();
             auto& value = std::get<7>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 8: {
+            FieldModelVector<FBE::buffer_t> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::vector<FBE::buffer_t>>();
+            auto& value = std::get<8>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 9: {
+            FieldModelVector<std::string> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::vector<std::string>>();
+            auto& value = std::get<9>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 10: {
+            FieldModelMap<int32_t, FBE::buffer_t> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::unordered_map<int32_t, FBE::buffer_t>>();
+            auto& value = std::get<10>(fbe_value);
+            fbe_model.get(value);
+            break;
+        }
+        case 11: {
+            FieldModelMap<std::string, FBE::buffer_t> fbe_model(_buffer, 4);
+            fbe_value.emplace<std::unordered_map<std::string, FBE::buffer_t>>();
+            auto& value = std::get<11>(fbe_value);
             fbe_model.get(value);
             break;
         }
@@ -272,6 +324,38 @@ void FieldModelVariant_variants_ptr_V::set(const ::variants_ptr::V& fbe_value) n
             }
             , [this, fbe_variant_index = fbe_value.index()](const std::unordered_map<int32_t, ::variants_ptr::Simple>& v) {
                 FieldModelCustomMap<FieldModel<int32_t>, FieldModel_variants_ptr_Simple, int32_t, ::variants_ptr::Simple> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::vector<FBE::buffer_t>& v) {
+                FieldModelVector<FBE::buffer_t> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::vector<std::string>& v) {
+                FieldModelVector<std::string> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::unordered_map<int32_t, FBE::buffer_t>& v) {
+                FieldModelMap<int32_t, FBE::buffer_t> fbe_model(_buffer, 4);
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
+                if (fbe_begin == 0)
+                    return;
+                fbe_model.set(v);
+                set_end(fbe_begin);
+            }
+            , [this, fbe_variant_index = fbe_value.index()](const std::unordered_map<std::string, FBE::buffer_t>& v) {
+                FieldModelMap<std::string, FBE::buffer_t> fbe_model(_buffer, 4);
                 size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;

--- a/proto/variants_ptr_ptr_models.cpp
+++ b/proto/variants_ptr_ptr_models.cpp
@@ -104,35 +104,35 @@ void FieldModelVariant_variants_ptr_V::get(::variants_ptr::V& fbe_value) const n
         case 0: {
             FieldModel<std::string> fbe_model(_buffer, 4);
             fbe_value.emplace<std::string>();
-            auto& value = std::get<std::string>(fbe_value);
+            auto& value = std::get<0>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 1: {
             FieldModel<int32_t> fbe_model(_buffer, 4);
             fbe_value.emplace<int32_t>();
-            auto& value = std::get<int32_t>(fbe_value);
+            auto& value = std::get<1>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 2: {
             FieldModel<double> fbe_model(_buffer, 4);
             fbe_value.emplace<double>();
-            auto& value = std::get<double>(fbe_value);
+            auto& value = std::get<2>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 3: {
             FieldModel_variants_ptr_Simple fbe_model(_buffer, 4);
             fbe_value.emplace<::variants_ptr::Simple>();
-            auto& value = std::get<::variants_ptr::Simple>(fbe_value);
+            auto& value = std::get<3>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 4: {
             FieldModelPtr_variants_ptr_Simple fbe_model(_buffer, 4);
             fbe_value.emplace<::variants_ptr::Simple*>();
-            auto& value = std::get<::variants_ptr::Simple*>(fbe_value);
+            auto& value = std::get<4>(fbe_value);
             fbe_model.get(&value);
             break;
         }
@@ -175,41 +175,41 @@ void FieldModelVariant_variants_ptr_V::set(const ::variants_ptr::V& fbe_value) n
     std::visit(
         overloaded
         {
-            [this, &fbe_value](const std::string& v) {
+            [this, fbe_variant_index = fbe_value.index()](const std::string& v) {
                 FieldModel<std::string> fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, &fbe_value](int32_t v) {
+            , [this, fbe_variant_index = fbe_value.index()](int32_t v) {
                 FieldModel<int32_t> fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, &fbe_value](double v) {
+            , [this, fbe_variant_index = fbe_value.index()](double v) {
                 FieldModel<double> fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, &fbe_value](const ::variants_ptr::Simple& v) {
+            , [this, fbe_variant_index = fbe_value.index()](const ::variants_ptr::Simple& v) {
                 FieldModel_variants_ptr_Simple fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, &fbe_value](::variants_ptr::Simple* v) {
+            , [this, fbe_variant_index = fbe_value.index()](const ::variants_ptr::Simple* v) {
                 FieldModelPtr_variants_ptr_Simple fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);
@@ -300,14 +300,14 @@ void FieldModelVariant_variants_ptr_Expr::get(::variants_ptr::Expr& fbe_value) c
         case 0: {
             FieldModel<bool> fbe_model(_buffer, 4);
             fbe_value.emplace<bool>();
-            auto& value = std::get<bool>(fbe_value);
+            auto& value = std::get<0>(fbe_value);
             fbe_model.get(value);
             break;
         }
         case 1: {
             FieldModel<int32_t> fbe_model(_buffer, 4);
             fbe_value.emplace<int32_t>();
-            auto& value = std::get<int32_t>(fbe_value);
+            auto& value = std::get<1>(fbe_value);
             fbe_model.get(value);
             break;
         }
@@ -350,17 +350,17 @@ void FieldModelVariant_variants_ptr_Expr::set(const ::variants_ptr::Expr& fbe_va
     std::visit(
         overloaded
         {
-            [this, &fbe_value](bool v) {
+            [this, fbe_variant_index = fbe_value.index()](bool v) {
                 FieldModel<bool> fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);
                 set_end(fbe_begin);
             }
-            , [this, &fbe_value](int32_t v) {
+            , [this, fbe_variant_index = fbe_value.index()](int32_t v) {
                 FieldModel<int32_t> fbe_model(_buffer, 4);
-                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());
+                size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);
                 if (fbe_begin == 0)
                     return;
                 fbe_model.set(v);

--- a/ptr_proto/variant.fbe
+++ b/ptr_proto/variant.fbe
@@ -14,6 +14,10 @@ variant V {
   Simple[];
   int32[];
   Simple{int32};
+  bytes[];
+  string[];
+  bytes{int32};
+  bytes{string};
 }
 
 variant Expr {

--- a/ptr_proto/variant.fbe
+++ b/ptr_proto/variant.fbe
@@ -18,6 +18,7 @@ variant V {
   string[];
   bytes{int32};
   bytes{string};
+  Simple*[];
 }
 
 variant Expr {

--- a/ptr_proto/variant.fbe
+++ b/ptr_proto/variant.fbe
@@ -11,6 +11,9 @@ variant V {
   double;
   Simple;
   Simple*;
+  Simple[];
+  int32[];
+  Simple{int32};
 }
 
 variant Expr {

--- a/source/fbe.cpp
+++ b/source/fbe.cpp
@@ -56,7 +56,7 @@ void VariantBody::AddValue(VariantValue* v)
         yyerror("Variant type is invalid!");
 
     // Check for duplicates
-    auto it = std::find_if(values.begin(), values.end(), [v](auto item)->bool { return *item->type.get() == *v->type.get() && item->ptr == v->ptr; });
+    auto it = std::find_if(values.begin(), values.end(), [v](auto item)->bool { return *item == *v; });
     if (it != values.end())
         yyerror("Duplicate Variant type " + *v->type.get());
 

--- a/source/fbe.y
+++ b/source/fbe.y
@@ -73,6 +73,10 @@ int yyerror(const std::string& msg);
 %type <variant_body> variant_body
 %type <variant_value> variant_value
 %type <variant_value> variant_value_base
+%type <variant_value> variant_value_vector
+%type <variant_value> variant_value_list
+%type <variant_value> variant_value_map
+%type <variant_value> variant_value_hash
 %type <variant_value> variant_value_base_ptr
 %type <struct_type> struct
 %type <boolean> struct_type
@@ -201,6 +205,10 @@ variant_body
 
 variant_value
     : variant_value_base ';'
+    | variant_value_vector ';'
+    | variant_value_list ';'
+    | variant_value_map ';'
+    | variant_value_hash ';'
     | variant_value_base_ptr ';'
     ;
 
@@ -225,6 +233,26 @@ variant_value_base
     | TIMESTAMP                                                                             { $$ = new FBE::VariantValue(); $$->type.reset($1); }
     | UUID                                                                                  { $$ = new FBE::VariantValue(); $$->type.reset($1); }
     | type_name                                                                             { $$ = new FBE::VariantValue(); $$->type.reset($1); }
+    ;
+
+variant_value_vector
+    : variant_value_base '[' ']'                                                             { $$ = $1; $$->vector = true; }
+    | variant_value_base_ptr '[' ']'                                                         { $$ = $1; $$->vector = true; }
+    ;
+
+variant_value_list
+    : variant_value_base '(' ')'                                                             { $$ = $1; $$->list = true; }
+    | variant_value_base_ptr '(' ')'                                                         { $$ = $1; $$->list = true; }
+    ;
+
+variant_value_map
+    : variant_value_base '<' variant_value_base '>'                                           { $$ = $1; $$->map = true; $$->key = $3->type; delete $3; }
+    | variant_value_base_ptr '<' variant_value_base '>'                                       { $$ = $1; $$->map = true; $$->key = $3->type; delete $3; }
+    ;
+
+variant_value_hash
+    : variant_value_base '{' variant_value_base '}'                                           { $$ = $1; $$->hash = true; $$->key = $3->type; delete $3; }
+    | variant_value_base_ptr '{' variant_value_base '}'                                       { $$ = $1; $$->hash = true; $$->key = $3->type; delete $3; }
     ;
 
 variant_value_base_ptr                                                                       
@@ -350,7 +378,7 @@ struct_field_base
     ;
 
 struct_field_base_ptr                                                                       
-    : type_name '*'                                                                         { $$ = new FBE::StructField(); $$->type.reset($1); $$->ptr = true ;}
+    : type_name '*'                                                                         { $$ = new FBE::StructField(); $$->type.reset($1); $$->ptr = true; }
     ;
 
 struct_field_optional

--- a/source/generator_cpp.cpp
+++ b/source/generator_cpp.cpp
@@ -8093,8 +8093,8 @@ void GeneratorCpp::GenerateVariantAlias(const std::shared_ptr<Package>& p, const
     WriteLine();
     std::string code = "using " + *v->name + " = std::variant<";
     bool first = true;
-    for (auto& value : v->body->values) {
-        code += (!first ? ", " : "") + ConvertTypeName(*p->name, *value->type, false) + (value->ptr ? "*" : "");
+    for (auto value : v->body->values) {
+        code += (!first ? ", " : "") + ConvertVariantTypeName(*p->name, *value);
         first = false;
     }
     code += ">;";

--- a/source/generator_cpp.cpp
+++ b/source/generator_cpp.cpp
@@ -8116,18 +8116,16 @@ void GeneratorCpp::GenerateVariantOutputStream(const std::shared_ptr<Package>& p
     Indent(1);
     bool first = true;
     for (auto& value : v->body->values) {
+        if (IsContainerType(*value) || value->ptr)
+            // TODO: Generate container output stream
+            continue;
         WriteIndent(first ? "" : ", ");
         Write("[&stream](");
-        auto type_name = ConvertTypeName(*p->name, *value->type, false);
-        if (IsPrimitiveType(*value->type, false))
-            Write(type_name);
-        else if (value->ptr)
-            Write(type_name + "*");
-        else 
-            Write("const " + type_name + "&");
+        Write(ConvertVariantTypeNameAsArgument(*p->name, *value));
         WriteLine(std::string(" v) { stream << ") + (value->ptr ? "*" : "") + "v; }");
         first = false;
     }
+    WriteLineIndent(", [&stream](auto&) { stream << \"unknown type\"; },");
     Indent(-1);
     WriteLineIndent("},");
     WriteLineIndent("value);");

--- a/source/generator_cpp.inl
+++ b/source/generator_cpp.inl
@@ -3600,7 +3600,6 @@ GeneratorCpp::ConvertPtrTypeName(const std::string &package, const StructField &
     if (Arena()) {
         prefix += "::pmr";
     }
-    // bool typeptr = withptr ? field.ptr : false;
     bool typeptr = field.ptr;
     if (field.array)
         return "std::array<" + ConvertPtrTypeName(package, *field.type, field.optional, typeptr, as_argument) + ", " + std::to_string(field.N) + ">";
@@ -3620,6 +3619,23 @@ GeneratorCpp::ConvertPtrTypeName(const std::string &package, const StructField &
     if (Ptr() && !IsKnownType(*field.type) && !field.ptr && as_argument)
         s += "&&";
     return s;
+}
+
+std::string GeneratorCpp::ConvertVariantTypeName(const std::string& package, const VariantValue& variant)
+{
+    std::string prefix = "std";
+    if (Arena()) {
+        prefix += "::pmr";
+    }
+    if (variant.vector)
+        return prefix + "::vector<" + ConvertPtrTypeName(package, *variant.type, false, variant.ptr, false) + ">";
+    else if (variant.list)
+        return prefix + "::list<" + ConvertPtrTypeName(package, *variant.type, false, variant.ptr, false) + ">";
+    else if (variant.map)
+        return prefix + "::map<" + ConvertPtrTypeName(package, *variant.key, false, false, false) + ", " + ConvertPtrTypeName(package, *variant.type, false, variant.ptr, false) +">";
+    else if (variant.hash)
+        return prefix + "::unordered_map<" + ConvertPtrTypeName(package, *variant.key, false, false, false) + ", " + ConvertPtrTypeName(package, *variant.type, false, variant.ptr, false) +">";
+    return ConvertPtrTypeName(package, *variant.type, false, variant.ptr, false);
 }
 
 // two cases:

--- a/source/generator_cpp.inl
+++ b/source/generator_cpp.inl
@@ -2507,10 +2507,10 @@ void GeneratorCpp::GenerateVariantFieldModel_Source(const std::shared_ptr<Packag
         auto& value = v->body->values[index];
         WriteLineIndent(ConvertPtrVariantFieldModelType(p, value) + " fbe_model(_buffer, 4);");
         // initialize variant
-        auto variant_type = ConvertTypeName(*p->name, *value->type, false) + (value->ptr ? "*": "");
+        auto variant_type = ConvertVariantTypeName(*p->name, *value);
         WriteLineIndent("fbe_value.emplace<" + variant_type + ">();");
-        WriteLineIndent("auto& value = std::get<" +  variant_type + ">(fbe_value);");
-        WriteLineIndent(std::string("fbe_model.get(") + (value->ptr ? "&" : "") + "value);");
+        WriteLineIndent("auto& value = std::get<" +  std::to_string(index) + ">(fbe_value);");
+        WriteLineIndent(std::string("fbe_model.get(") + ((!IsContainerType(*value) && value->ptr) ? "&" : "") + "value);");
         WriteLineIndent("break;");
         Indent(-1);
         WriteLineIndent("}");
@@ -2580,18 +2580,12 @@ void GeneratorCpp::GenerateVariantFieldModel_Source(const std::shared_ptr<Packag
     for(auto index = 0; index < v->body->values.size(); index ++) {
         WriteIndent(first ? "" : ", ");
         auto& value = v->body->values[index];
-        Write("[this, &fbe_value](");
-        auto type_name = ConvertTypeName(*p->name, *value->type, false);
-        if (IsPrimitiveType(*value->type, false))
-            Write(type_name);
-        else if (value->ptr)
-            Write(type_name + "*");
-        else 
-            Write("const " + type_name + "&");
+        Write("[this, fbe_variant_index = fbe_value.index()](");
+        Write(ConvertVariantTypeNameAsArgument(*p->name, *value));
         WriteLine(" v) {");
         Indent(1);
         WriteLineIndent(ConvertPtrVariantFieldModelType(p, value) + " fbe_model(_buffer, 4);");
-        WriteLineIndent("size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_value.index());");
+        WriteLineIndent("size_t fbe_begin = set_begin(fbe_model.fbe_size(), fbe_variant_index);");
         WriteLineIndent("if (fbe_begin == 0)");
         Indent(1);
         WriteLineIndent("return;");
@@ -3520,6 +3514,10 @@ bool GeneratorCpp::IsContainerType(const StructField &field) {
     return (field.array || field.vector || field.list || field.set || field.map || field.hash);
 }
 
+bool GeneratorCpp::IsContainerType(const VariantValue &variant) {
+    return (variant.vector || variant.list || variant.map || variant.hash);
+}
+
 bool GeneratorCpp::IsStructType(const std::shared_ptr<Package>& p, const std::string& field_type) {
     for (const auto &s:  p->body->structs) {
         if (*s->name == field_type) {
@@ -3638,14 +3636,25 @@ std::string GeneratorCpp::ConvertVariantTypeName(const std::string& package, con
     return ConvertPtrTypeName(package, *variant.type, false, variant.ptr, false);
 }
 
+std::string GeneratorCpp::ConvertVariantTypeNameAsArgument(const std::string& package, const VariantValue& variant)
+{
+    if (variant.ptr) {
+        return "const " + ConvertVariantTypeName(package, variant);
+    }
+    if (IsContainerType(variant))
+        return "const " + ConvertVariantTypeName(package, variant) + "&";
+    if (IsPrimitiveType(*variant.type, false)) {
+        return ConvertVariantTypeName(package, variant);
+    }
+    return "const " + ConvertVariantTypeName(package, variant) + "&";
+}
+
 // two cases:
 // 1. struct should be rvalue references, because we disable copy cstr
 // 2. for container of ptrs, use unique_ptr instead.
 std::string GeneratorCpp::ConvertPtrTypeNameAsArgument(const std::string& package, const StructField& field)
 {
-    if (field.ptr)
-        return ConvertPtrTypeName(package, field, true);
-    if (IsPrimitiveType(*field.type, false))
+    if (field.ptr || IsPrimitiveType(*field.type, false))
         return ConvertPtrTypeName(package, field, true);
     if (IsKnownType(*field.type))
         return "const " + ConvertPtrTypeName(package, field, true) + "&";
@@ -3700,10 +3709,39 @@ std::string GeneratorCpp::ConvertPtrFieldModelType(const std::shared_ptr<Package
 
 std::string GeneratorCpp::ConvertPtrVariantFieldModelType(const std::shared_ptr<Package>& p, const std::shared_ptr<VariantValue>& variant) {
     std::string variant_field_model_type;
-     if (Ptr() && IsStructType(p, *variant->type) && !IsKnownType(*variant->type)) {
-        variant_field_model_type = std::string("FieldModel") + (variant->ptr ? "Ptr" : "") + "_" + *p->name + "_" + *variant->type;
-     } else
-        variant_field_model_type = "FieldModel<" + ConvertPtrTypeName(*p->name, *variant->type, false, variant->ptr, false) + ">";
+    if (Ptr()) {
+        if (IsStructType(p, *variant->type) && !IsKnownType(*variant->type)) {
+            std::string model_name = std::string("FieldModel") + (variant->ptr ? "Ptr" : "") + "_" + *p->name + "_" + *variant->type;
+            if (IsContainerType(*variant)) {
+                variant_field_model_type = "FieldModel";
+                if (variant->vector || variant->list)
+                    variant_field_model_type += "CustomVector<" + model_name + ", " + ConvertPtrTypeName(*p->name, *variant->type) + ">";
+                else if (variant->map || variant->hash){
+                    std::string kType = "FieldModel";
+                    if (IsKnownType(*variant->key)) {
+                        kType += "<" + ConvertPtrTypeName(*p->name, *variant->key) + ">";
+                    } else {
+                        kType +=  "_" + *p->name + "_" + *variant->type;
+                    }
+                    auto kStruct = ConvertPtrTypeName(*p->name, *variant->key);
+                    auto vStruct = ConvertPtrTypeName(*p->name, *variant->type);
+                    variant_field_model_type += "CustomMap<" + kType + ", " + model_name + ", " + kStruct  + ", " + vStruct + ">";
+                }
+            } else {
+                variant_field_model_type += model_name;
+            }
+        }  else if (variant->vector || variant->list)
+            variant_field_model_type = "FieldModelVector<" + ConvertPtrTypeName(*p->name, *variant->type, false, variant->ptr, false) + ">";
+        else if (variant->map || variant->hash)
+            variant_field_model_type = "FieldModelMap<" + ConvertPtrTypeName(*p->name, *variant->key) + ", " + ConvertPtrTypeName(*p->name, *variant->type, false, variant->ptr, false) + ">";
+        else
+            variant_field_model_type = "FieldModel<" + ConvertPtrTypeName(*p->name, *variant->type, false, variant->ptr, false) + ">";
+    } else if (variant->vector || variant->list) // template based
+        variant_field_model_type = "FieldModelVector<" + ConvertTypeName(*p->name, *variant->type, false) + ">";
+    else if (variant->map || variant->hash)
+        variant_field_model_type = "FieldModelMap<" + ConvertTypeName(*p->name, *variant->key, false) + ", " + ConvertTypeName(*p->name, *variant->type, false) + ">";
+    else
+        variant_field_model_type = "FieldModel<" + ConvertTypeName(*p->name, *variant->type, false) + ">";
     return variant_field_model_type;
 }
 

--- a/tests/test_serialization_ptr.cpp
+++ b/tests/test_serialization_ptr.cpp
@@ -454,7 +454,8 @@ TEST_CASE("Serialization (ptr-based import templated-based fbe)", "[Ptr-based FB
 
 TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
     SECTION ("string") {
-        ::variants_ptr::Value value{"variant v"};
+        ::variants_ptr::Value value;
+        value.v.emplace<std::string>("variant v");
 
         FBE::variants_ptr::ValueModel writer;
         size_t serialized = writer.serialize(value);
@@ -474,7 +475,8 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
     }
 
     SECTION ("primitive type") {
-        ::variants_ptr::Value value{42};
+        ::variants_ptr::Value value;
+        value.v.emplace<int32_t>(42);
 
         FBE::variants_ptr::ValueModel writer;
         size_t serialized = writer.serialize(value);
@@ -494,8 +496,8 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
     }
 
     SECTION ("struct") {
-        ::variants_ptr::Simple simple{"simple"};
-        ::variants_ptr::Value value(std::move(simple));
+        ::variants_ptr::Value value;
+        value.v.emplace<::variants_ptr::Simple>(::variants_ptr::Simple{"simple"});
 
         FBE::variants_ptr::ValueModel writer;
         size_t serialized = writer.serialize(value);
@@ -516,7 +518,8 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
 
     SECTION ("pointer") {
         auto simple = std::make_unique<::variants_ptr::Simple>("simple");
-        ::variants_ptr::Value value(simple.get());
+        ::variants_ptr::Value value;
+        value.v.emplace<::variants_ptr::Simple*>(simple.get());
 
         FBE::variants_ptr::ValueModel writer;
         size_t serialized = writer.serialize(value);
@@ -534,4 +537,38 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
         REQUIRE(value_copy.v.index() == 4);
         REQUIRE(std::get<::variants_ptr::Simple*>(value_copy.v)->name == "simple");
     }
+
+    // SECTION ("vector of struct") {
+    //     std::vector<::variants_ptr::Simple> v;
+    //     v.emplace_back(::variants_ptr::Simple{"simple1"});
+    //     v.emplace_back(::variants_ptr::Simple{"simple2"});
+
+    //     // ::variants_ptr::Value value;
+    //     // value.v = std::move(v);
+
+    //     // FBE::variants_ptr::ValueModel writer;
+    //     // size_t serialized = writer.serialize(value);
+    //     // std::cout << "serialized: " << serialized << std::endl;
+    //     // REQUIRE(serialized == writer.buffer().size());
+    //     // REQUIRE(writer.verify());
+
+    //     // FBE::variants_ptr::ValueModel reader;
+    //     // reader.attach(writer.buffer());
+    //     // REQUIRE(reader.verify());
+
+    //     // std::cout << "start deserialize: " << std::endl;
+
+    //     // ::variants_ptr::Value value_copy;
+    //     // size_t deserialized = reader.deserialize(value_copy);
+    //     // std::cout << "deserialized: " << deserialized << std::endl;
+    //     // REQUIRE(deserialized == reader.buffer().size());
+
+    //     // REQUIRE(value_copy.v.index() == 5);
+    //     // auto& v_copy = std::get<std::vector<::variants_ptr::Simple>>(value_copy.v);
+    //     // REQUIRE(v_copy.size() == 2);
+    //     // REQUIRE(v_copy.at(0).name == "simple1");
+    //     // REQUIRE(v_copy.at(1).name == "simple2");
+
+    //     std::cout << "done" << std::endl;
+    // }
 }

--- a/tests/test_serialization_ptr.cpp
+++ b/tests/test_serialization_ptr.cpp
@@ -625,4 +625,115 @@ TEST_CASE("Serialization (variant)", "[Ptr-based FBE]") {
         REQUIRE(v_copy.at(1).name == "simple1");
         REQUIRE(v_copy.at(2).name == "simple2");
     }
+    
+    SECTION ("container of bytes") {
+        std::vector<uint8_t> v {65, 66, 67, 68, 69};
+        std::vector<FBE::buffer_t> bytes_v;
+        bytes_v.emplace_back(FBE::buffer_t(v));
+
+        ::variants_ptr::Value value;
+        REQUIRE(value.v.index() == 0);
+        value.v.emplace<8>(std::move(bytes_v));
+
+        FBE::variants_ptr::ValueModel writer;
+        size_t serialized = writer.serialize(value);
+        REQUIRE(serialized == writer.buffer().size());
+        REQUIRE(writer.verify());
+
+        FBE::variants_ptr::ValueModel reader;
+        reader.attach(writer.buffer());
+        REQUIRE(reader.verify());
+
+        ::variants_ptr::Value value_copy;
+        size_t deserialized = reader.deserialize(value_copy);
+        REQUIRE(deserialized == reader.buffer().size());
+
+        REQUIRE(value_copy.v.index() == 8);
+        auto& v_copy = std::get<8>(value_copy.v);
+        REQUIRE(v_copy.size() == 1);
+        REQUIRE(v_copy.at(0).string() == "ABCDE");
+    }
+    
+    SECTION ("vector of string") {
+        std::vector<std::string> string_v {"hello", "world"};
+
+        ::variants_ptr::Value value;
+        REQUIRE(value.v.index() == 0);
+        value.v.emplace<9>(std::move(string_v));
+
+        FBE::variants_ptr::ValueModel writer;
+        size_t serialized = writer.serialize(value);
+        REQUIRE(serialized == writer.buffer().size());
+        REQUIRE(writer.verify());
+
+        FBE::variants_ptr::ValueModel reader;
+        reader.attach(writer.buffer());
+        REQUIRE(reader.verify());
+
+        ::variants_ptr::Value value_copy;
+        size_t deserialized = reader.deserialize(value_copy);
+        REQUIRE(deserialized == reader.buffer().size());
+
+        REQUIRE(value_copy.v.index() == 9);
+        auto& v_copy = std::get<9>(value_copy.v);
+        REQUIRE(v_copy.size() == 2);
+        REQUIRE(v_copy.at(0) == "hello");
+        REQUIRE(v_copy.at(1) == "world");
+    }
+
+    SECTION ("hash with primitive and bytes") {
+        std::unordered_map<int32_t, FBE::buffer_t> m;
+        std::vector<uint8_t> v {65, 66, 67, 68, 69};
+        m.emplace(42, FBE::buffer_t(v));
+
+        ::variants_ptr::Value value;
+        REQUIRE(value.v.index() == 0);
+        value.v.emplace<10>(std::move(m));
+
+        FBE::variants_ptr::ValueModel writer;
+        size_t serialized = writer.serialize(value);
+        REQUIRE(serialized == writer.buffer().size());
+        REQUIRE(writer.verify());
+
+        FBE::variants_ptr::ValueModel reader;
+        reader.attach(writer.buffer());
+        REQUIRE(reader.verify());
+
+        ::variants_ptr::Value value_copy;
+        size_t deserialized = reader.deserialize(value_copy);
+        REQUIRE(deserialized == reader.buffer().size());
+
+        REQUIRE(value_copy.v.index() == 10);
+        auto& v_copy = std::get<10>(value_copy.v);
+        REQUIRE(v_copy.size() == 1);
+        REQUIRE(v_copy.at(42).string() == "ABCDE");
+    }
+
+    SECTION ("hash with string and bytes") {
+        std::unordered_map<std::string, FBE::buffer_t> m;
+        std::vector<uint8_t> v {65, 66, 67, 68, 69};
+        m.emplace("hello world", FBE::buffer_t(v));
+
+        ::variants_ptr::Value value;
+        REQUIRE(value.v.index() == 0);
+        value.v.emplace<11>(std::move(m));
+
+        FBE::variants_ptr::ValueModel writer;
+        size_t serialized = writer.serialize(value);
+        REQUIRE(serialized == writer.buffer().size());
+        REQUIRE(writer.verify());
+
+        FBE::variants_ptr::ValueModel reader;
+        reader.attach(writer.buffer());
+        REQUIRE(reader.verify());
+
+        ::variants_ptr::Value value_copy;
+        size_t deserialized = reader.deserialize(value_copy);
+        REQUIRE(deserialized == reader.buffer().size());
+
+        REQUIRE(value_copy.v.index() == 11);
+        auto& v_copy = std::get<11>(value_copy.v);
+        REQUIRE(v_copy.size() == 1);
+        REQUIRE(v_copy.at("hello world").string() == "ABCDE");
+    }
 }


### PR DESCRIPTION
This PR will make variant type work with [all FBE collections types except array](https://chronoxor.github.io/FastBinaryEncoding/documents/FBE.html#collections)

#### Limitations: 
1. If variant type has pointer type as the given type of collections, you should free on your own.

