### PR TITLE
Add overloaded deduction guide

### DIFF
--- a/proto/fbe.h
+++ b/proto/fbe.h
@@ -93,6 +93,8 @@ auto assign_member([[maybe_unused]] Alloc alloc) -> T {
 
 template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;  // deduction guide
+
 //! Bytes buffer type
 /*!
     Represents bytes buffer which is a lightweight wrapper around std::vector<uint8_t>

--- a/source/generator_cpp.cpp
+++ b/source/generator_cpp.cpp
@@ -390,6 +390,8 @@ void GeneratorCpp::GenerateVariantVisitHelper_Header()
 {
     std::string code = R"CODE(
 template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;  // deduction guide
 )CODE";
 
     // Prepare code template


### PR DESCRIPTION
Since clang does not support C++ 20 feature `class template argument deduction for aggregates`, we need to add deduction guide for the overloaded pattern.