### PR TITLE
replace ArenaManagedCreateOnlyTag to ArenaFullManagedTag, because

### DIFF
--- a/include/generator_cpp.h
+++ b/include/generator_cpp.h
@@ -44,7 +44,7 @@ public:
 
     std::string ArenaHeader() const noexcept { return "memory/arena/arena.hpp"; }
 
-    std::vector<std::string> ArenaTags() const noexcept { return {"ArenaManagedCreateOnlyTag"}; }
+    std::vector<std::string> ArenaTags() const noexcept { return {"ArenaFullManagedTag"}; }
 
     bool ImportPtr() const noexcept { return _import_ptr; }
     GeneratorCpp& ImportPtr(bool import_ptr) noexcept { _import_ptr = import_ptr; return *this; }


### PR DESCRIPTION
memory::string need be destroy while not in SSO small mode.